### PR TITLE
[KOEMPF] Correct path to abstract.php

### DIFF
--- a/shell/cron/turpentineUrlCacheStatus.php
+++ b/shell/cron/turpentineUrlCacheStatus.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'abstract.php';
+require_once '..' . DIRECTORY_SEPARATOR . 'abstract.php';
 
 class TurpentineUrlCacheStatus extends Mage_Shell_Abstract
 {


### PR DESCRIPTION
abstract.php can not be loaded, because __DIR__ points to the composer path vendor/flagbit/magento-turpentine/shell/cron/